### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/PublishGEM.md
+++ b/PublishGEM.md
@@ -1,11 +1,11 @@
-###Publish
+### Publish
 1. 生成 xxx-version.gem 文件`gem build xxx.gemspec`
 2. 发布到rubygems.org `gem push xxx-0.0.1.gem`
 
-###Troubleshooting
+### Troubleshooting
 1. 删除错误的发布，记住版本号一定要加`gem yank xxx -v 0.01`
 
-###Help
+### Help
 1. 查看本地安装的gem `gem list`
 2. 安装gem `gem install ${gem_name}`
 3. 卸载gem `gem uninstall ${gem_name}`

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CrashMonkey4IOS
 iOS Monkey Test Tool.
 
-###简要说明:
+### 简要说明:
 1. 支持**真机测试、模拟器测试**
 2. 支持收集**系统日志(Systemlog)**、**崩溃日志(Crashlog)**、***instrument行为日志***
 3. 支持测试报告截图，绘制行为轨迹
@@ -17,7 +17,7 @@ iOS Monkey Test Tool.
   [tp]:https://github.com/vigossjjj/CrashMonkey4IOS/tree/master/lib/ui-auto-monkey/tuneup
   [troubleshooting]:https://github.com/vigossjjj/CrashMonkey4IOS/tree/master/Troubleshooting.md
 
-###系统及环境要求:
+### 系统及环境要求:
 1. 安装Ruby运行环境，建议不要使用OS X自带版本，可自行使用RVM([Ruby Version Manager](http://www.ruby-lang.org/en/downloads/))安装最新版的Ruby。安装好RVM后建议使用淘宝镜像安装ruby，
 
  `$ sed -i -e 's/ftp\.ruby-lang\.org\/pub\/ruby/ruby\.taobao\.org\/mirrors\/ruby/g' ~/.rvm/config/db`
@@ -32,12 +32,12 @@ iOS Monkey Test Tool.
 3. 安装**Homebrew** `ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`
 4. 建议Xcode 6.x +
 
-###必要依赖安装:
+### 必要依赖安装:
 1. `brew install -HEAD ideviceinstaller`
 2. `brew install libimobiledevice`
 3. `brew install imagemagick`
 
-###使用说明:
+### 使用说明:
 ###### 安装Release版
 `gem install smart_monkey`, 执行入口: 终端下直接使用`smart_monkey`
 ###### 安装开发版
@@ -47,7 +47,7 @@ iOS Monkey Test Tool.
 ###### 执行命令
 `smart_monkey -a ${App_BunnelID} -w ${iPhone_UDID}`
 
-###参数说明:
+### 参数说明:
 
 * **`-a`**: 指向被测程序的**BundleID**(不可缺省)。e.g.`-a com.mytest.app`
 * **`-w`**: 指向测试设备的**UDID**，可以通过`$instruments -s devices`进行设备id的查看，若缺省则默认指向第一台设备(模拟器或真机)。e.g.`-w 26701a3a5bc17038ca0465186407b912375b35a7`
@@ -99,10 +99,10 @@ Usage: smart_monkey [options]
         --version                    print smart monkey version
 ```
 
-###Troubleshooting:
+### Troubleshooting:
 安装和执行测试遇到的问题解决方案请参看:[Troubleshooting.md][troubleshooting]
 
-###测试报告:
+### 测试报告:
 ***Summary:***
 <img alt="summary" src="https://github.com/vigossjjj/CrashMonkey4IOS/blob/master/img/summary.jpg">
 ***Detail:***
@@ -114,6 +114,6 @@ Usage: smart_monkey [options]
 ***uiautotrace:***
 <img alt="uiautotrace" src="https://github.com/vigossjjj/CrashMonkey4IOS/blob/master/img/uiauto_trace.jpg">
 
-###参考文献：
+### 参考文献：
 1. https://github.com/mokemokechicken/CrashMonkey
 2. https://github.com/jonathanpenn/ui-auto-monkey

--- a/To-Do-List.md
+++ b/To-Do-List.md
@@ -1,4 +1,4 @@
-##To-Do-List##
+## To-Do-List ##
 1. ~~优化在真机Monkey运行过程当中判定app拉入后台的规则。~~
 2. 加入iPhone Simulator对app拉入后台的判定，及re-launch机制。
 3. 添加handler可参数化配置

--- a/Troubleshooting.md
+++ b/Troubleshooting.md
@@ -1,4 +1,4 @@
-#Troubleshooting for CrashMonkey4IOS
+# Troubleshooting for CrashMonkey4IOS
 
 CrashMonkey4IOS 安装环节中的问题总结和处理。
 
@@ -15,7 +15,7 @@ CrashMonkey4IOS 开发环境：OS X Yosemtie 10.10.x
 3.确保被测app被移至后台后进程不会被强制杀死。
 
 
-####安装过程使用reset.sh时(推荐执行前手动更新本地的ruby和homebrew版本)
+#### 安装过程使用reset.sh时(推荐执行前手动更新本地的ruby和homebrew版本)
 ***问题1: gem install erubis 需要用户本地的管理员权限***
 
 如果没有安装成功这个erubis模块的话会在/CrashMonkey4IOS/bin下运行 ./smart_monkey 后ruby报错 erubis的错误：


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
